### PR TITLE
Fix date inputs to use local timezone

### DIFF
--- a/ui/src/app/components/timebar/timebar.component.ts
+++ b/ui/src/app/components/timebar/timebar.component.ts
@@ -105,8 +105,10 @@ export class TimebarComponent implements OnInit, OnDestroy {
 
   constructor() {
     const today = new Date();
-    this.startDate = today.toISOString();
-    this.endDate = today.toISOString();
+    today.setMinutes(today.getMinutes() - today.getTimezoneOffset());
+    const isoDate = today.toISOString().split('T')[0];
+    this.startDate = isoDate;
+    this.endDate = isoDate;
   }
 
   ngOnInit() {

--- a/ui/src/app/components/timeline/timeline.component.ts
+++ b/ui/src/app/components/timeline/timeline.component.ts
@@ -47,8 +47,10 @@ export class TimelineComponent implements OnInit, AfterViewInit {
 
   constructor() {
     const today = new Date();
-    this.startDate = today.toISOString();
-    this.endDate = today.toISOString();
+    today.setMinutes(today.getMinutes() - today.getTimezoneOffset());
+    const isoDate = today.toISOString().split('T')[0];
+    this.startDate = isoDate;
+    this.endDate = isoDate;
   }
 
   ngOnInit() {

--- a/ui/src/app/components/timepie/timepie.component.ts
+++ b/ui/src/app/components/timepie/timepie.component.ts
@@ -103,8 +103,10 @@ export class TimepieComponent implements OnInit {
 
   constructor() {
     const today = new Date();
-    this.startDate = today.toISOString();
-    this.endDate = today.toISOString();
+    today.setMinutes(today.getMinutes() - today.getTimezoneOffset());
+    const isoDate = today.toISOString().split('T')[0];
+    this.startDate = isoDate;
+    this.endDate = isoDate;
   }
 
   async ngOnInit() {


### PR DESCRIPTION
## Summary
- avoid UTC in timeline, timepie, and timebar date defaults

## Testing
- `npm test` *(fails: ng not found)*
- `pytest` *(fails: command not found)*